### PR TITLE
Updated `merge` dependency version to `1.2.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3432,7 +3432,7 @@
       "integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
       "dev": true,
       "requires": {
-        "merge": "1.2.0"
+        "merge": "1.2.1"
       }
     },
     "exit-hook": {


### PR DESCRIPTION
# CVE-2018-16469 (high severity)
**Vulnerable versions:** < 1.2.1
**Patched version:** 1.2.1

The merge.recursive function in the merge package in versions before 1.2.1 can be tricked into adding or modifying properties of the Object prototype. These properties will be present on all objects allowing for a denial of service attack.